### PR TITLE
Check indexes on create

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -45,4 +45,6 @@
 	'Auth\\Model\\Auth_Rolepermission'  => __DIR__.'/classes/model/auth/rolepermission.php',
 	'Auth\\Model\\Auth_Permission'      => __DIR__.'/classes/model/auth/permission.php',
 	'Auth\\Model\\Auth_Provider'        => __DIR__.'/classes/model/auth/provider.php',
+
+	'Auth\\Migration' => __DIR__.'/classes/migration.php',
 ));

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -12,7 +12,9 @@
 
 namespace Auth;
 
-class AuthException extends \FuelException {}
+class AuthException extends \FuelException
+{
+}
 
 /**
  * Auth
@@ -22,492 +24,442 @@ class AuthException extends \FuelException {}
  */
 class Auth
 {
-	/**
-	 * @var  Auth_Login_Driver	default instance
-	 */
-	protected static $_instance = null;
+    /**
+     * @var  Auth_Login_Driver	default instance
+     */
+    protected static $_instance = null;
 
-	/**
-	 * @var  Array  contains references if multiple were loaded
-	 */
-	protected static $_instances = array();
+    /**
+     * @var  Array  contains references if multiple were loaded
+     */
+    protected static $_instances = array();
 
-	/**
-	 * @var  Array  Login drivers that verified a current login
-	 */
-	protected static $_verified = array();
+    /**
+     * @var  Array  Login drivers that verified a current login
+     */
+    protected static $_verified = array();
 
-	/**
-	 * @var  bool  Whether to verify multiple
-	 */
-	protected static $_verify_multiple = false;
+    /**
+     * @var  bool  Whether to verify multiple
+     */
+    protected static $_verify_multiple = false;
 
-	/**
-	 * @var  Array  subdriver registry, takes driver name and method for checking it
-	 */
-	protected static $_drivers = array(
-		'group'  => 'member',
-		'acl'    => 'has_access',
-	);
+    /**
+     * @var  Array  subdriver registry, takes driver name and method for checking it
+     */
+    protected static $_drivers = array(
+        'group'  => 'member',
+        'acl'    => 'has_access',
+    );
 
-	public static function _init()
-	{
-		\Config::load('auth', true);
+    public static function _init()
+    {
+        \Config::load('auth', true);
 
-		foreach((array) \Config::get('auth.driver', array()) as $driver => $config)
-		{
-			$config = is_int($driver)
-				? array('driver' => $config)
-				: array_merge($config, array('driver' => $driver));
-			static::forge($config);
-		}
+        foreach ((array) \Config::get('auth.driver', array()) as $driver => $config) {
+            $config = is_int($driver)
+                ? array('driver' => $config)
+                : array_merge($config, array('driver' => $driver));
+            static::forge($config);
+        }
 
-		// Set the first (or only) as the default instance for static usage
-		if ( ! empty(static::$_instances))
-		{
-			static::$_instance = reset(static::$_instances);
-			static::check();
-		}
-	}
+        // Set the first (or only) as the default instance for static usage
+        if (! empty(static::$_instances)) {
+            static::$_instance = reset(static::$_instances);
+            static::check();
+        }
+    }
 
-	/**
-	 * Load a login driver to the array of loaded drivers
-	 *
-	 * @param   Array  settings for the new driver
-	 * @throws  AuthException  on driver load failure
-	 */
-	public static function forge($custom = array())
-	{
-		// Driver is given as array key or just string in custom
-		$custom = ! is_array($custom) ? array('driver' => $custom) : $custom;
-		$config = \Config::get('auth.'.$custom['driver'].'_config', array());
-		$config = array_merge($config, $custom);
+    /**
+     * Load a login driver to the array of loaded drivers
+     *
+     * @param   Array  settings for the new driver
+     * @throws  AuthException  on driver load failure
+     */
+    public static function forge($custom = array())
+    {
+        // Driver is given as array key or just string in custom
+        $custom = ! is_array($custom) ? array('driver' => $custom) : $custom;
+        $config = \Config::get('auth.'.$custom['driver'].'_config', array());
+        $config = array_merge($config, $custom);
 
-		// Driver must be set
-		if (empty($config['driver']) || ! is_string($config['driver']))
-		{
-			throw new \AuthException('No auth driver given.');
-		}
+        // Driver must be set
+        if (empty($config['driver']) || ! is_string($config['driver'])) {
+            throw new \AuthException('No auth driver given.');
+        }
 
-		// determine the driver to load
-		$driver = \Auth_Login_Driver::forge($config);
+        // determine the driver to load
+        $driver = \Auth_Login_Driver::forge($config);
 
-		// get the driver's cookie name
-		$id = $driver->get_id();
+        // get the driver's cookie name
+        $id = $driver->get_id();
 
-		// do we already have a driver instance for this cookie?
-		if (isset(static::$_instances[$id]))
-		{
-			// if so, they must be using the same driver class!
-			$class = get_class($driver);
-			if ( ! static::$_instances[$id] instanceof $class)
-			{
-				throw new \AuthException('You can not instantiate two different login drivers using the same id "'.$id.'"');
-			}
-		}
-		else
-		{
-			// store this instance
-			static::$_instances[$id] = $driver;
-		}
+        // do we already have a driver instance for this cookie?
+        if (isset(static::$_instances[$id])) {
+            // if so, they must be using the same driver class!
+            $class = get_class($driver);
+            if (! static::$_instances[$id] instanceof $class) {
+                throw new \AuthException('You can not instantiate two different login drivers using the same id "'.$id.'"');
+            }
+        } else {
+            // store this instance
+            static::$_instances[$id] = $driver;
+        }
 
-		// If we have more then one driver instance, check if we need concurrency
-		if (count(static::$_instances) > 1)
-		{
-			// Whether to allow multiple drivers of any type, defaults to not allowed
-			static::$_verify_multiple = \Config::get('auth.verify_multiple_logins', false);
-		}
+        // If we have more then one driver instance, check if we need concurrency
+        if (count(static::$_instances) > 1) {
+            // Whether to allow multiple drivers of any type, defaults to not allowed
+            static::$_verify_multiple = \Config::get('auth.verify_multiple_logins', false);
+        }
 
-		return static::$_instances[$id];
-	}
+        return static::$_instances[$id];
+    }
 
-	/**
-	 * Prevent instantiation
-	 */
-	final private function __construct() {}
+    /**
+     * Prevent instantiation
+     */
+    final private function __construct()
+    {
+    }
 
-	/**
-	 * Remove individual driver, or all drivers of $type
-	 *
-	 * @param   string  driver id or null for default driver
-	 * @throws  AuthException  when $driver_id isn't valid or true
-	 */
-	public static function unload($driver_id = null)
-	{
-		if ($driver_id === null && ! empty(static::$_instance))
-		{
-			unset(static::$_instances[static::$_instance->get_id()]);
-			static::$_instance = null;
-			return true;
-		}
-		elseif (array_key_exists($driver_id, static::$_instances))
-		{
-			return false;
-		}
+    /**
+     * Remove individual driver, or all drivers of $type
+     *
+     * @param   string  driver id or null for default driver
+     * @throws  AuthException  when $driver_id isn't valid or true
+     */
+    public static function unload($driver_id = null)
+    {
+        if ($driver_id === null && ! empty(static::$_instance)) {
+            unset(static::$_instances[static::$_instance->get_id()]);
+            static::$_instance = null;
+            return true;
+        } elseif (array_key_exists($driver_id, static::$_instances)) {
+            return false;
+        }
 
-		unset(static::$_instances[$driver_id]);
-		return true;
-	}
+        unset(static::$_instances[$driver_id]);
+        return true;
+    }
 
-	/**
-	 * Return a specific driver, or the default instance (is created if necessary)
-	 *
-	 * @param   string  driver id
-	 * @return  Auth_Login_Driver
-	 */
-	public static function instance($instance = null)
-	{
-		if ($instance !== null)
-		{
-			if ( ! array_key_exists($instance, static::$_instances))
-			{
-				return false;
-			}
+    /**
+     * Return a specific driver, or the default instance (is created if necessary)
+     *
+     * @param   string  driver id
+     * @return  Auth_Login_Driver
+     */
+    public static function instance($instance = null)
+    {
+        if ($instance !== null) {
+            if (! array_key_exists($instance, static::$_instances)) {
+                return false;
+            }
 
-			return static::$_instances[$instance];
-		}
+            return static::$_instances[$instance];
+        }
 
-		if (static::$_instance === null)
-		{
-			static::$_instance = static::forge();
-		}
+        if (static::$_instance === null) {
+            static::$_instance = static::forge();
+        }
 
-		return static::$_instance;
-	}
+        return static::$_instance;
+    }
 
-	/**
-	 * Check login drivers for validated login
-	 *
-	 * @param   string|Array  specific driver or drivers, in this case it will always terminate after first success
-	 * @return  bool
-	 */
-	public static function check($specific = null)
-	{
-		$drivers = $specific === null ? static::$_instances : (array) $specific;
-		$verified = static::$_verified;
+    /**
+     * Check login drivers for validated login
+     *
+     * @param   string|Array  specific driver or drivers, in this case it will always terminate after first success
+     * @return  bool
+     */
+    public static function check($specific = null)
+    {
+        $drivers = $specific === null ? static::$_instances : (array) $specific;
+        $verified = static::$_verified;
 
-		if ($specific !== null)
-		{
-			$verified = array();
-			foreach ($drivers as $i)
-			{
-				$i = $i instanceof Auth_Login_Driver ? $i : static::instance($i);
-				$key = $i->get_id();
-				if (isset(static::$_verified[$key])) $verified[$key] = static::$_verified[$key];
-			}
-		}
+        if ($specific !== null) {
+            $verified = array();
+            foreach ($drivers as $i) {
+                $i = $i instanceof Auth_Login_Driver ? $i : static::instance($i);
+                $key = $i->get_id();
+                if (isset(static::$_verified[$key])) {
+                    $verified[$key] = static::$_verified[$key];
+                }
+            }
+        }
 
-		foreach ($drivers as $i)
-		{
-			if ( ! static::$_verify_multiple && ! empty($verified))
-			{
-				return true;
-			}
+        foreach ($drivers as $i) {
+            if (! static::$_verify_multiple && ! empty($verified)) {
+                return true;
+            }
 
-			$i = $i instanceof Auth_Login_Driver ? $i : static::instance($i);
-			if ( ! array_key_exists($i->get_id(), $verified))
-			{
-				$i->check();
-			}
+            $i = $i instanceof Auth_Login_Driver ? $i : static::instance($i);
+            if (! array_key_exists($i->get_id(), $verified)) {
+                $i->check();
+            }
 
-			if ($specific)
-			{
-				if (array_key_exists($i->get_id(), $verified))
-				{
-					return true;
-				}
-			}
-		}
+            if ($specific) {
+                if (array_key_exists($i->get_id(), $verified)) {
+                    return true;
+                }
+            }
+        }
 
-		return $specific === null && ! empty($verified);
-	}
+        return $specific === null && ! empty($verified);
+    }
 
-	/**
-	 * Get verified driver or all verified drivers
-	 * returns false when specific driver has not validated
-	 * when all were requested and none validated an empty array is returned
-	 *
-	 * @param   null|string  driver id or null for all verified driver in an array
-	 * @return  Array|Auth_Login_Driver|false
-	 */
-	public static function verified($driver = null)
-	{
-		if ($driver === null)
-		{
-			return static::$_verified;
-		}
+    /**
+     * Get verified driver or all verified drivers
+     * returns false when specific driver has not validated
+     * when all were requested and none validated an empty array is returned
+     *
+     * @param   null|string  driver id or null for all verified driver in an array
+     * @return  Array|Auth_Login_Driver|false
+     */
+    public static function verified($driver = null)
+    {
+        if ($driver === null) {
+            return static::$_verified;
+        }
 
-		if ( ! array_key_exists($driver, static::$_verified))
-		{
-			return false;
-		}
+        if (! array_key_exists($driver, static::$_verified)) {
+            return false;
+        }
 
-		return static::$_verified[$driver];
-	}
+        return static::$_verified[$driver];
+    }
 
-	/**
-	 * Login user
-	 *
-	 * @param   string
-	 * @param   string
-	 * @return  bool
-	 */
-	public static function login($username_or_email = '', $password = '')
-	{
-		$loggedin = false;
+    /**
+     * Login user
+     *
+     * @param   string
+     * @param   string
+     * @return  bool
+     */
+    public static function login($username_or_email = '', $password = '')
+    {
+        $loggedin = false;
 
-		foreach (static::$_instances as $i)
-		{
-			if ($i instanceof Auth_Login_Driver)
-			{
-				if ($i->login($username_or_email, $password))
-				{
-					$loggedin = true;
-					if ( ! static::$_verify_multiple)
-					{
-						break;
-					}
-				}
-			}
-		}
+        foreach (static::$_instances as $i) {
+            if ($i instanceof Auth_Login_Driver) {
+                if ($i->login($username_or_email, $password)) {
+                    $loggedin = true;
+                    if (! static::$_verify_multiple) {
+                        break;
+                    }
+                }
+            }
+        }
 
-		return $loggedin;
-	}
+        return $loggedin;
+    }
 
-	/**
-	 * Logs out all current logged in drivers
-	 */
-	public static function logout()
-	{
-		foreach (static::$_verified as $v)
-		{
-			$v->logout();
-		}
+    /**
+     * Logs out all current logged in drivers
+     */
+    public static function logout()
+    {
+        foreach (static::$_verified as $v) {
+            $v->logout();
+        }
 
-		static::$_verified = array();
-	}
+        static::$_verified = array();
+    }
 
-	/**
-	 * Register verified Login driver
-	 *
-	 * @param  Auth_Login_Driver
-	 */
-	public static function _register_verified(Auth_Login_Driver $driver)
-	{
-		static::$_verified[$driver->get_id()] = $driver;
-	}
+    /**
+     * Register verified Login driver
+     *
+     * @param  Auth_Login_Driver
+     */
+    public static function _register_verified(Auth_Login_Driver $driver)
+    {
+        static::$_verified[$driver->get_id()] = $driver;
+    }
 
-	/**
-	 * Unregister verified Login driver
-	 *
-	 * @param  Auth_Login_Driver
-	 */
-	public static function _unregister_verified(Auth_Login_Driver $driver)
-	{
-		unset(static::$_verified[$driver->get_id()]);
-	}
+    /**
+     * Unregister verified Login driver
+     *
+     * @param  Auth_Login_Driver
+     */
+    public static function _unregister_verified(Auth_Login_Driver $driver)
+    {
+        unset(static::$_verified[$driver->get_id()]);
+    }
 
-	/**
-	 * Register a new driver type
-	 *
-	 * @param   string  name of the driver type, may not conflict with class method name
-	 * @param   string  name of the method to use for checking this type of driver, also cannot conflict with method
-	 * @return  bool
-	 */
-	public static function register_driver_type($type, $check_method)
-	{
-		$driver_exists = ! is_string($type)
-						|| array_key_exists($type, static::$_drivers)
-						|| method_exists(get_called_class(), $check_method)
-						|| in_array($type, array('login', 'group', 'acl'));
-		$method_exists = ! is_string($type)
-						|| array_search($check_method, static::$_drivers)
-						|| method_exists(get_called_class(), $type);
+    /**
+     * Register a new driver type
+     *
+     * @param   string  name of the driver type, may not conflict with class method name
+     * @param   string  name of the method to use for checking this type of driver, also cannot conflict with method
+     * @return  bool
+     */
+    public static function register_driver_type($type, $check_method)
+    {
+        $driver_exists = ! is_string($type)
+                        || array_key_exists($type, static::$_drivers)
+                        || method_exists(get_called_class(), $check_method)
+                        || in_array($type, array('login', 'group', 'acl'));
+        $method_exists = ! is_string($type)
+                        || array_search($check_method, static::$_drivers)
+                        || method_exists(get_called_class(), $type);
 
-		if ($driver_exists && static::$_drivers[$type] == $check_method)
-		{
-			return true;
-		}
+        if ($driver_exists && static::$_drivers[$type] == $check_method) {
+            return true;
+        }
 
-		if ($driver_exists || $method_exists)
-		{
-			\Errorhandler::notice('Cannot add driver type, its name conflicts with another driver or method.');
-			return false;
-		}
+        if ($driver_exists || $method_exists) {
+            \Errorhandler::notice('Cannot add driver type, its name conflicts with another driver or method.');
+            return false;
+        }
 
-		static::$_drivers[$type] = $check_method;
-		return true;
-	}
+        static::$_drivers[$type] = $check_method;
+        return true;
+    }
 
-	/**
-	 * Unregister a driver type
-	 *
-	 * @param   string  name of the driver type
-	 * @return  bool
-	 */
-	public static function unregister_driver_type($type)
-	{
-		if (in_array($type, array('login', 'group', 'acl')))
-		{
-			\Errorhandler::notice('Cannot remove driver type, included drivers login, group and acl cannot be removed.');
-			return false;
-		}
+    /**
+     * Unregister a driver type
+     *
+     * @param   string  name of the driver type
+     * @return  bool
+     */
+    public static function unregister_driver_type($type)
+    {
+        if (in_array($type, array('login', 'group', 'acl'))) {
+            \Errorhandler::notice('Cannot remove driver type, included drivers login, group and acl cannot be removed.');
+            return false;
+        }
 
-		unset(static::$_drivers[$type]);
-		return true;
-	}
+        unset(static::$_drivers[$type]);
+        return true;
+    }
 
-	/**
-	 * Magic method used to retrieve driver instances and check them for validity
-	 *
-	 * @param   string
-	 * @param   array
-	 * @return  mixed
-	 * @throws  BadMethodCallException
-	 */
-	public static function __callStatic($method, $args)
-	{
-		$args = array_pad($args, 3, null);
-		if (array_key_exists($method, static::$_drivers))
-		{
-			return static::_driver_instance($method, $args[0]);
-		}
-		if ($type = array_search($method, static::$_drivers))
-		{
-			return static::_driver_check($type, $args[0], $args[1], @$args[2]);
-		}
-		if (static::$_verify_multiple !== true and method_exists(static::$_instance, $method))
-		{
-			return call_fuel_func_array(array(static::$_instance, $method), $args);
-		}
+    /**
+     * Magic method used to retrieve driver instances and check them for validity
+     *
+     * @param   string
+     * @param   array
+     * @return  mixed
+     * @throws  BadMethodCallException
+     */
+    public static function __callStatic($method, $args)
+    {
+        $args = array_pad($args, 3, null);
+        if (array_key_exists($method, static::$_drivers)) {
+            return static::_driver_instance($method, $args[0]);
+        }
+        if ($type = array_search($method, static::$_drivers)) {
+            return static::_driver_check($type, $args[0], $args[1], @$args[2]);
+        }
+        if (static::$_verify_multiple !== true and method_exists(static::$_instance, $method)) {
+            return call_fuel_func_array(array(static::$_instance, $method), $args);
+        }
 
-		throw new \BadMethodCallException('Invalid method: '.get_called_class().'::'.$method);
-	}
+        throw new \BadMethodCallException('Invalid method: '.get_called_class().'::'.$method);
+    }
 
-	/**
-	 * Retrieve a loaded driver instance
-	 * (loading must be done by other driver class)
-	 *
-	 * @param   string       driver type
-	 * @param   string|true  driver id or true for an array of all loaded drivers
-	 * @return  Auth_Driver|array
-	 */
-	protected static function _driver_instance($type, $instance)
-	{
-		$class = 'Auth_'.\Str::ucwords($type).'_Driver';
-		return $class::instance($instance);
-	}
+    /**
+     * Retrieve a loaded driver instance
+     * (loading must be done by other driver class)
+     *
+     * @param   string       driver type
+     * @param   string|true  driver id or true for an array of all loaded drivers
+     * @return  Auth_Driver|array
+     */
+    protected static function _driver_instance($type, $instance)
+    {
+        $class = 'Auth_'.\Str::ucwords($type).'_Driver';
+        return $class::instance($instance);
+    }
 
-	/**
-	 * Check driver
-	 *
-	 * @param   string  driver type
-	 * @param   mixed   condition for which the driver is checked
-	 * @param   string  driver id or null to check all
-	 * @param   Array   identifier to check, should default to current user or relation therof and be
-	 *                  in the form of array(driver_id, user_id)
-	 * @return bool
-	 */
-	public static function _driver_check($type, $condition, $driver = null, $entity = null)
-	{
-		$method = static::$_drivers[$type];
-		if ($driver === null)
-		{
-			if ($entity === null)
-			{
-				if ( ! empty(static::$_verified))
-				{
-					foreach (static::$_verified as $v)
-					{
-						if ($v->$method($condition))
-						{
-							return true;
-						}
-					}
-				}
-				else
-				{
-					foreach (static::$_instances as $i)
-					{
-						if ($i->guest_login() and $i->$method($condition))
-						{
-							return true;
-						}
-					}
-				}
-			}
-			else
-			{
-				foreach (static::$_instances as $i)
-				{
-					if ($i->$method($condition, null, $entity))
-					{
-						return true;
-					}
-				}
-			}
-			return false;
-		}
-		else
-		{
-			if ($entity === null)
-			{
-				foreach (static::$_verified as $v)
-				{
-					if (static::$type($driver)->$method($condition))
-					{
-						return true;
-					}
-				}
-			}
-			elseif (static::$type($driver)->$method($condition, $entity))
-			{
-				return true;
-			}
+    /**
+     * Check driver
+     *
+     * @param   string  driver type
+     * @param   mixed   condition for which the driver is checked
+     * @param   string  driver id or null to check all
+     * @param   Array   identifier to check, should default to current user or relation therof and be
+     *                  in the form of array(driver_id, user_id)
+     * @return bool
+     */
+    public static function _driver_check($type, $condition, $driver = null, $entity = null)
+    {
+        $method = static::$_drivers[$type];
+        if ($driver === null) {
+            if ($entity === null) {
+                if (! empty(static::$_verified)) {
+                    foreach (static::$_verified as $v) {
+                        if ($v->$method($condition)) {
+                            return true;
+                        }
+                    }
+                } else {
+                    foreach (static::$_instances as $i) {
+                        if ($i->guest_login() and $i->$method($condition)) {
+                            return true;
+                        }
+                    }
+                }
+            } else {
+                foreach (static::$_instances as $i) {
+                    if ($i->$method($condition, null, $entity)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        } else {
+            if ($entity === null) {
+                foreach (static::$_verified as $v) {
+                    if (static::$type($driver)->$method($condition)) {
+                        return true;
+                    }
+                }
+            } elseif (static::$type($driver)->$method($condition, $entity)) {
+                return true;
+            }
 
-			return false;
-		}
-	}
+            return false;
+        }
+    }
 
-	public static function has_role($role_id = null, $user = null)
-	{
-		if (! is_array($role_id)) {
-			$role_id = array($role_id);
-		}
+    public static function has_role($role_id = null, $user = null)
+    {
+        if (! is_array($role_id)) {
+            $role_id = array($role_id);
+        }
 
-		if ($user === null && static::instance()) {
-			$user = static::get_user();
-		}
+        if ($user === null && static::instance()) {
+            $user = static::get_user();
+        }
 
-		if ($user instanceof Model\Auth_User && ($user->roles || $user->group)) {
-			$roles = $user->roles;
-			if ($user->group && $user->group->roles) {
-				$roles = array_merge($roles, $user->group->roles);
-			}
+        if ($user instanceof Model\Auth_User && ($user->roles || $user->group)) {
+            $roles = $user->roles;
+            if ($user->group && $user->group->roles) {
+                $roles = array_merge($roles, $user->group->roles);
+            }
 
-			foreach ($roles as $role) {
-				foreach ($role_id as $test_role) {
-					$tocheck = $role->name;
+            foreach ($roles as $role) {
+                foreach ($role_id as $test_role) {
+                    $tocheck = $role->name;
 
-					// asterisk means "any of"
-					if (substr($test_role, -2) === '.*') {
-						// remove down to full stop on test_role
-						$test_role = substr($test_role, 0, -1);
+                    // asterisk means "any of"
+                    if (substr($test_role, -2) === '.*') {
+                        // remove down to full stop on test_role
+                        $test_role = substr($test_role, 0, -1);
 
-						// don't worry about the full stop, just go for a match against test role
-						// anything more would be overkill
-						$tocheck = substr($tocheck, 0, strlen($test_role));
-					}
+                        // don't worry about the full stop, just go for a match against test role
+                        // anything more would be overkill
+                        $tocheck = substr($tocheck, 0, strlen($test_role));
+                    }
 
-					if ($tocheck == $test_role) {
-						return true;
-					}
-				}
-			}
-		}
+                    if ($tocheck == $test_role) {
+                        return true;
+                    }
+                }
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 }
 
 /* end of file auth.php */

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -12,9 +12,7 @@
 
 namespace Auth;
 
-class AuthException extends \FuelException
-{
-}
+class AuthException extends \FuelException {}
 
 /**
  * Auth
@@ -24,482 +22,492 @@ class AuthException extends \FuelException
  */
 class Auth
 {
-    /**
-     * @var  Auth_Login_Driver	default instance
-     */
-    protected static $_instance = null;
+	/**
+	 * @var  Auth_Login_Driver	default instance
+	 */
+	protected static $_instance = null;
 
-    /**
-     * @var  Array  contains references if multiple were loaded
-     */
-    protected static $_instances = array();
+	/**
+	 * @var  Array  contains references if multiple were loaded
+	 */
+	protected static $_instances = array();
 
-    /**
-     * @var  Array  Login drivers that verified a current login
-     */
-    protected static $_verified = array();
+	/**
+	 * @var  Array  Login drivers that verified a current login
+	 */
+	protected static $_verified = array();
 
-    /**
-     * @var  bool  Whether to verify multiple
-     */
-    protected static $_verify_multiple = false;
+	/**
+	 * @var  bool  Whether to verify multiple
+	 */
+	protected static $_verify_multiple = false;
 
-    /**
-     * @var  Array  subdriver registry, takes driver name and method for checking it
-     */
-    protected static $_drivers = array(
-        'group'  => 'member',
-        'acl'    => 'has_access',
-    );
+	/**
+	 * @var  Array  subdriver registry, takes driver name and method for checking it
+	 */
+	protected static $_drivers = array(
+		'group'  => 'member',
+		'acl'    => 'has_access',
+	);
 
-    public static function _init()
-    {
-        \Config::load('auth', true);
+	public static function _init()
+	{
+		\Config::load('auth', true);
 
-        foreach ((array) \Config::get('auth.driver', array()) as $driver => $config) {
-            $config = is_int($driver)
-                ? array('driver' => $config)
-                : array_merge($config, array('driver' => $driver));
-            static::forge($config);
-        }
+		foreach((array) \Config::get('auth.driver', array()) as $driver => $config)
+		{
+			$config = is_int($driver)
+				? array('driver' => $config)
+				: array_merge($config, array('driver' => $driver));
+			static::forge($config);
+		}
 
-        // Set the first (or only) as the default instance for static usage
-        if (! empty(static::$_instances)) {
-            static::$_instance = reset(static::$_instances);
-            static::check();
-        }
-    }
+		// Set the first (or only) as the default instance for static usage
+		if ( ! empty(static::$_instances))
+		{
+			static::$_instance = reset(static::$_instances);
+			static::check();
+		}
+	}
 
-    /**
-     * Load a login driver to the array of loaded drivers
-     *
-     * @param   Array  settings for the new driver
-     * @throws  AuthException  on driver load failure
-     */
-    public static function forge($custom = array())
-    {
-        // Driver is given as array key or just string in custom
-        $custom = ! is_array($custom) ? array('driver' => $custom) : $custom;
-        $config = \Config::get('auth.'.$custom['driver'].'_config', array());
-        $config = array_merge($config, $custom);
+	/**
+	 * Load a login driver to the array of loaded drivers
+	 *
+	 * @param   Array  settings for the new driver
+	 * @throws  AuthException  on driver load failure
+	 */
+	public static function forge($custom = array())
+	{
+		// Driver is given as array key or just string in custom
+		$custom = ! is_array($custom) ? array('driver' => $custom) : $custom;
+		$config = \Config::get('auth.'.$custom['driver'].'_config', array());
+		$config = array_merge($config, $custom);
 
-        // Driver must be set
-        if (empty($config['driver']) || ! is_string($config['driver'])) {
-            throw new \AuthException('No auth driver given.');
-        }
+		// Driver must be set
+		if (empty($config['driver']) || ! is_string($config['driver']))
+		{
+			throw new \AuthException('No auth driver given.');
+		}
 
-        // determine the driver to load
-        $driver = \Auth_Login_Driver::forge($config);
+		// determine the driver to load
+		$driver = \Auth_Login_Driver::forge($config);
 
-        // get the driver's cookie name
-        $id = $driver->get_id();
+		// get the driver's cookie name
+		$id = $driver->get_id();
 
-        // do we already have a driver instance for this cookie?
-        if (isset(static::$_instances[$id])) {
-            // if so, they must be using the same driver class!
-            $class = get_class($driver);
-            if (! static::$_instances[$id] instanceof $class) {
-                throw new \AuthException('You can not instantiate two different login drivers using the same id "'.$id.'"');
-            }
-        } else {
-            // store this instance
-            static::$_instances[$id] = $driver;
-        }
+		// do we already have a driver instance for this cookie?
+		if (isset(static::$_instances[$id]))
+		{
+			// if so, they must be using the same driver class!
+			$class = get_class($driver);
+			if ( ! static::$_instances[$id] instanceof $class)
+			{
+				throw new \AuthException('You can not instantiate two different login drivers using the same id "'.$id.'"');
+			}
+		}
+		else
+		{
+			// store this instance
+			static::$_instances[$id] = $driver;
+		}
 
-        // If we have more then one driver instance, check if we need concurrency
-        if (count(static::$_instances) > 1) {
-            // Whether to allow multiple drivers of any type, defaults to not allowed
-            static::$_verify_multiple = \Config::get('auth.verify_multiple_logins', false);
-        }
+		// If we have more then one driver instance, check if we need concurrency
+		if (count(static::$_instances) > 1)
+		{
+			// Whether to allow multiple drivers of any type, defaults to not allowed
+			static::$_verify_multiple = \Config::get('auth.verify_multiple_logins', false);
+		}
 
-        return static::$_instances[$id];
-    }
+		return static::$_instances[$id];
+	}
 
-    /**
-     * Prevent instantiation
-     */
-    final private function __construct()
-    {
-    }
+	/**
+	 * Prevent instantiation
+	 */
+	final private function __construct() {}
 
-    /**
-     * Remove individual driver, or all drivers of $type
-     *
-     * @param   string  driver id or null for default driver
-     * @throws  AuthException  when $driver_id isn't valid or true
-     */
-    public static function unload($driver_id = null)
-    {
-        if ($driver_id === null && ! empty(static::$_instance)) {
-            unset(static::$_instances[static::$_instance->get_id()]);
-            static::$_instance = null;
-            return true;
-        } elseif (array_key_exists($driver_id, static::$_instances)) {
-            return false;
-        }
+	/**
+	 * Remove individual driver, or all drivers of $type
+	 *
+	 * @param   string  driver id or null for default driver
+	 * @throws  AuthException  when $driver_id isn't valid or true
+	 */
+	public static function unload($driver_id = null)
+	{
+		if ($driver_id === null && ! empty(static::$_instance))
+		{
+			unset(static::$_instances[static::$_instance->get_id()]);
+			static::$_instance = null;
+			return true;
+		}
+		elseif (array_key_exists($driver_id, static::$_instances))
+		{
+			return false;
+		}
 
-        unset(static::$_instances[$driver_id]);
-        return true;
-    }
+		unset(static::$_instances[$driver_id]);
+		return true;
+	}
 
-    /**
-     * Return a specific driver, or the default instance (is created if necessary)
-     *
-     * @param   string  driver id
-     * @return  Auth_Login_Driver
-     */
-    public static function instance($instance = null)
-    {
-        if ($instance !== null) {
-            if (! array_key_exists($instance, static::$_instances)) {
-                return false;
-            }
+	/**
+	 * Return a specific driver, or the default instance (is created if necessary)
+	 *
+	 * @param   string  driver id
+	 * @return  Auth_Login_Driver
+	 */
+	public static function instance($instance = null)
+	{
+		if ($instance !== null)
+		{
+			if ( ! array_key_exists($instance, static::$_instances))
+			{
+				return false;
+			}
 
-            return static::$_instances[$instance];
-        }
+			return static::$_instances[$instance];
+		}
 
-        if (static::$_instance === null) {
-            static::$_instance = static::forge();
-        }
+		if (static::$_instance === null)
+		{
+			static::$_instance = static::forge();
+		}
 
-        return static::$_instance;
-    }
+		return static::$_instance;
+	}
 
-    /**
-     * Check login drivers for validated login
-     *
-     * @param   string|Array  specific driver or drivers, in this case it will always terminate after first success
-     * @return  bool
-     */
-    public static function check($specific = null)
-    {
-        $drivers = $specific === null ? static::$_instances : (array) $specific;
-        $verified = static::$_verified;
+	/**
+	 * Check login drivers for validated login
+	 *
+	 * @param   string|Array  specific driver or drivers, in this case it will always terminate after first success
+	 * @return  bool
+	 */
+	public static function check($specific = null)
+	{
+		$drivers = $specific === null ? static::$_instances : (array) $specific;
+		$verified = static::$_verified;
 
-        if ($specific !== null) {
-            $verified = array();
-            foreach ($drivers as $i) {
-                $i = $i instanceof Auth_Login_Driver ? $i : static::instance($i);
-                $key = $i->get_id();
-                if (isset(static::$_verified[$key])) {
-                    $verified[$key] = static::$_verified[$key];
-                }
-            }
-        }
+		if ($specific !== null)
+		{
+			$verified = array();
+			foreach ($drivers as $i)
+			{
+				$i = $i instanceof Auth_Login_Driver ? $i : static::instance($i);
+				$key = $i->get_id();
+				if (isset(static::$_verified[$key])) $verified[$key] = static::$_verified[$key];
+			}
+		}
 
-        foreach ($drivers as $i) {
-            if (! static::$_verify_multiple && ! empty($verified)) {
-                return true;
-            }
+		foreach ($drivers as $i)
+		{
+			if ( ! static::$_verify_multiple && ! empty($verified))
+			{
+				return true;
+			}
 
-            $i = $i instanceof Auth_Login_Driver ? $i : static::instance($i);
-            if (! array_key_exists($i->get_id(), $verified)) {
-                $i->check();
-            }
+			$i = $i instanceof Auth_Login_Driver ? $i : static::instance($i);
+			if ( ! array_key_exists($i->get_id(), $verified))
+			{
+				$i->check();
+			}
 
-            if ($specific) {
-                if (array_key_exists($i->get_id(), $verified)) {
-                    return true;
-                }
-            }
-        }
+			if ($specific)
+			{
+				if (array_key_exists($i->get_id(), $verified))
+				{
+					return true;
+				}
+			}
+		}
 
-        return $specific === null && ! empty($verified);
-    }
+		return $specific === null && ! empty($verified);
+	}
 
-    /**
-     * Get verified driver or all verified drivers
-     * returns false when specific driver has not validated
-     * when all were requested and none validated an empty array is returned
-     *
-     * @param   null|string  driver id or null for all verified driver in an array
-     * @return  Array|Auth_Login_Driver|false
-     */
-    public static function verified($driver = null)
-    {
-        if ($driver === null) {
-            return static::$_verified;
-        }
+	/**
+	 * Get verified driver or all verified drivers
+	 * returns false when specific driver has not validated
+	 * when all were requested and none validated an empty array is returned
+	 *
+	 * @param   null|string  driver id or null for all verified driver in an array
+	 * @return  Array|Auth_Login_Driver|false
+	 */
+	public static function verified($driver = null)
+	{
+		if ($driver === null)
+		{
+			return static::$_verified;
+		}
 
-        if (! array_key_exists($driver, static::$_verified)) {
-            return false;
-        }
+		if ( ! array_key_exists($driver, static::$_verified))
+		{
+			return false;
+		}
 
-        return static::$_verified[$driver];
-    }
+		return static::$_verified[$driver];
+	}
 
-    /**
-     * Login user
-     *
-     * @param   string
-     * @param   string
-     * @return  bool
-     */
-    public static function login($username_or_email = '', $password = '')
-    {
-        $loggedin = false;
+	/**
+	 * Login user
+	 *
+	 * @param   string
+	 * @param   string
+	 * @return  bool
+	 */
+	public static function login($username_or_email = '', $password = '')
+	{
+		$loggedin = false;
 
-        foreach (static::$_instances as $i) {
-            if ($i instanceof Auth_Login_Driver) {
-                if ($i->login($username_or_email, $password)) {
-                    $loggedin = true;
-                    if (! static::$_verify_multiple) {
-                        break;
-                    }
-                }
-            }
-        }
+		foreach (static::$_instances as $i)
+		{
+			if ($i instanceof Auth_Login_Driver)
+			{
+				if ($i->login($username_or_email, $password))
+				{
+					$loggedin = true;
+					if ( ! static::$_verify_multiple)
+					{
+						break;
+					}
+				}
+			}
+		}
 
-        return $loggedin;
-    }
+		return $loggedin;
+	}
 
-    /**
-     * Logs out all current logged in drivers
-     */
-    public static function logout()
-    {
-        foreach (static::$_verified as $v) {
-            $v->logout();
-        }
+	/**
+	 * Logs out all current logged in drivers
+	 */
+	public static function logout()
+	{
+		foreach (static::$_verified as $v)
+		{
+			$v->logout();
+		}
 
-        static::$_verified = array();
-    }
+		static::$_verified = array();
+	}
 
-    /**
-     * Register verified Login driver
-     *
-     * @param  Auth_Login_Driver
-     */
-    public static function _register_verified(Auth_Login_Driver $driver)
-    {
-        static::$_verified[$driver->get_id()] = $driver;
-    }
+	/**
+	 * Register verified Login driver
+	 *
+	 * @param  Auth_Login_Driver
+	 */
+	public static function _register_verified(Auth_Login_Driver $driver)
+	{
+		static::$_verified[$driver->get_id()] = $driver;
+	}
 
-    /**
-     * Unregister verified Login driver
-     *
-     * @param  Auth_Login_Driver
-     */
-    public static function _unregister_verified(Auth_Login_Driver $driver)
-    {
-        unset(static::$_verified[$driver->get_id()]);
-    }
+	/**
+	 * Unregister verified Login driver
+	 *
+	 * @param  Auth_Login_Driver
+	 */
+	public static function _unregister_verified(Auth_Login_Driver $driver)
+	{
+		unset(static::$_verified[$driver->get_id()]);
+	}
 
-    /**
-     * Register a new driver type
-     *
-     * @param   string  name of the driver type, may not conflict with class method name
-     * @param   string  name of the method to use for checking this type of driver, also cannot conflict with method
-     * @return  bool
-     */
-    public static function register_driver_type($type, $check_method)
-    {
-        $driver_exists = ! is_string($type)
-                        || array_key_exists($type, static::$_drivers)
-                        || method_exists(get_called_class(), $check_method)
-                        || in_array($type, array('login', 'group', 'acl'));
-        $method_exists = ! is_string($type)
-                        || array_search($check_method, static::$_drivers)
-                        || method_exists(get_called_class(), $type);
+	/**
+	 * Register a new driver type
+	 *
+	 * @param   string  name of the driver type, may not conflict with class method name
+	 * @param   string  name of the method to use for checking this type of driver, also cannot conflict with method
+	 * @return  bool
+	 */
+	public static function register_driver_type($type, $check_method)
+	{
+		$driver_exists = ! is_string($type)
+						|| array_key_exists($type, static::$_drivers)
+						|| method_exists(get_called_class(), $check_method)
+						|| in_array($type, array('login', 'group', 'acl'));
+		$method_exists = ! is_string($type)
+						|| array_search($check_method, static::$_drivers)
+						|| method_exists(get_called_class(), $type);
 
-        if ($driver_exists && static::$_drivers[$type] == $check_method) {
-            return true;
-        }
+		if ($driver_exists && static::$_drivers[$type] == $check_method)
+		{
+			return true;
+		}
 
-        if ($driver_exists || $method_exists) {
-            \Errorhandler::notice('Cannot add driver type, its name conflicts with another driver or method.');
-            return false;
-        }
+		if ($driver_exists || $method_exists)
+		{
+			\Errorhandler::notice('Cannot add driver type, its name conflicts with another driver or method.');
+			return false;
+		}
 
-        static::$_drivers[$type] = $check_method;
-        return true;
-    }
+		static::$_drivers[$type] = $check_method;
+		return true;
+	}
 
-    /**
-     * Unregister a driver type
-     *
-     * @param   string  name of the driver type
-     * @return  bool
-     */
-    public static function unregister_driver_type($type)
-    {
-        if (in_array($type, array('login', 'group', 'acl'))) {
-            \Errorhandler::notice('Cannot remove driver type, included drivers login, group and acl cannot be removed.');
-            return false;
-        }
+	/**
+	 * Unregister a driver type
+	 *
+	 * @param   string  name of the driver type
+	 * @return  bool
+	 */
+	public static function unregister_driver_type($type)
+	{
+		if (in_array($type, array('login', 'group', 'acl')))
+		{
+			\Errorhandler::notice('Cannot remove driver type, included drivers login, group and acl cannot be removed.');
+			return false;
+		}
 
-        unset(static::$_drivers[$type]);
-        return true;
-    }
+		unset(static::$_drivers[$type]);
+		return true;
+	}
 
-    /**
-     * Magic method used to retrieve driver instances and check them for validity
-     *
-     * @param   string
-     * @param   array
-     * @return  mixed
-     * @throws  BadMethodCallException
-     */
-    public static function __callStatic($method, $args)
-    {
-        $args = array_pad($args, 3, null);
-        if (array_key_exists($method, static::$_drivers)) {
-            return static::_driver_instance($method, $args[0]);
-        }
-        if ($type = array_search($method, static::$_drivers)) {
-            return static::_driver_check($type, $args[0], $args[1], @$args[2]);
-        }
-        if (static::$_verify_multiple !== true and method_exists(static::$_instance, $method)) {
-            return call_fuel_func_array(array(static::$_instance, $method), $args);
-        }
+	/**
+	 * Magic method used to retrieve driver instances and check them for validity
+	 *
+	 * @param   string
+	 * @param   array
+	 * @return  mixed
+	 * @throws  BadMethodCallException
+	 */
+	public static function __callStatic($method, $args)
+	{
+		$args = array_pad($args, 3, null);
+		if (array_key_exists($method, static::$_drivers))
+		{
+			return static::_driver_instance($method, $args[0]);
+		}
+		if ($type = array_search($method, static::$_drivers))
+		{
+			return static::_driver_check($type, $args[0], $args[1], @$args[2]);
+		}
+		if (static::$_verify_multiple !== true and method_exists(static::$_instance, $method))
+		{
+			return call_fuel_func_array(array(static::$_instance, $method), $args);
+		}
 
-        throw new \BadMethodCallException('Invalid method: '.get_called_class().'::'.$method);
-    }
+		throw new \BadMethodCallException('Invalid method: '.get_called_class().'::'.$method);
+	}
 
-    /**
-     * Retrieve a loaded driver instance
-     * (loading must be done by other driver class)
-     *
-     * @param   string       driver type
-     * @param   string|true  driver id or true for an array of all loaded drivers
-     * @return  Auth_Driver|array
-     */
-    protected static function _driver_instance($type, $instance)
-    {
-        $class = 'Auth_'.\Str::ucwords($type).'_Driver';
-        return $class::instance($instance);
-    }
+	/**
+	 * Retrieve a loaded driver instance
+	 * (loading must be done by other driver class)
+	 *
+	 * @param   string       driver type
+	 * @param   string|true  driver id or true for an array of all loaded drivers
+	 * @return  Auth_Driver|array
+	 */
+	protected static function _driver_instance($type, $instance)
+	{
+		$class = 'Auth_'.\Str::ucwords($type).'_Driver';
+		return $class::instance($instance);
+	}
 
-    /**
-     * Check driver
-     *
-     * @param   string  driver type
-     * @param   mixed   condition for which the driver is checked
-     * @param   string  driver id or null to check all
-     * @param   Array   identifier to check, should default to current user or relation therof and be
-     *                  in the form of array(driver_id, user_id)
-     * @return bool
-     */
-    public static function _driver_check($type, $condition, $driver = null, $entity = null)
-    {
-        $method = static::$_drivers[$type];
-        if ($driver === null) {
-            if ($entity === null) {
-                if (! empty(static::$_verified)) {
-                    foreach (static::$_verified as $v) {
-                        if ($v->$method($condition)) {
-                            return true;
-                        }
-                    }
-                } else {
-                    foreach (static::$_instances as $i) {
-                        if ($i->guest_login() and $i->$method($condition)) {
-                            return true;
-                        }
-                    }
-                }
-            } else {
-                foreach (static::$_instances as $i) {
-                    if ($i->$method($condition, null, $entity)) {
-                        return true;
-                    }
-                }
-            }
-            return false;
-        } else {
-            if ($entity === null) {
-                foreach (static::$_verified as $v) {
-                    if (static::$type($driver)->$method($condition)) {
-                        return true;
-                    }
-                }
-            } elseif (static::$type($driver)->$method($condition, $entity)) {
-                return true;
-            }
+	/**
+	 * Check driver
+	 *
+	 * @param   string  driver type
+	 * @param   mixed   condition for which the driver is checked
+	 * @param   string  driver id or null to check all
+	 * @param   Array   identifier to check, should default to current user or relation therof and be
+	 *                  in the form of array(driver_id, user_id)
+	 * @return bool
+	 */
+	public static function _driver_check($type, $condition, $driver = null, $entity = null)
+	{
+		$method = static::$_drivers[$type];
+		if ($driver === null)
+		{
+			if ($entity === null)
+			{
+				if ( ! empty(static::$_verified))
+				{
+					foreach (static::$_verified as $v)
+					{
+						if ($v->$method($condition))
+						{
+							return true;
+						}
+					}
+				}
+				else
+				{
+					foreach (static::$_instances as $i)
+					{
+						if ($i->guest_login() and $i->$method($condition))
+						{
+							return true;
+						}
+					}
+				}
+			}
+			else
+			{
+				foreach (static::$_instances as $i)
+				{
+					if ($i->$method($condition, null, $entity))
+					{
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+		else
+		{
+			if ($entity === null)
+			{
+				foreach (static::$_verified as $v)
+				{
+					if (static::$type($driver)->$method($condition))
+					{
+						return true;
+					}
+				}
+			}
+			elseif (static::$type($driver)->$method($condition, $entity))
+			{
+				return true;
+			}
 
-            return false;
-        }
-    }
+			return false;
+		}
+	}
 
-    public static function has_role($role_id = null, $user = null)
-    {
-        if (! is_array($role_id)) {
-            $role_id = array($role_id);
-        }
+	public static function has_role($role_id = null, $user = null)
+	{
+		if (! is_array($role_id)) {
+			$role_id = array($role_id);
+		}
 
-        if ($user === null && static::instance()) {
-            $user = static::get_user();
-        }
+		if ($user === null && static::instance()) {
+			$user = static::get_user();
+		}
 
-        if ($user instanceof Model\Auth_User && ($user->roles || $user->group)) {
-            $roles = $user->roles;
-            if ($user->group && $user->group->roles) {
-                $roles = array_merge($roles, $user->group->roles);
-            }
+		if ($user instanceof Model\Auth_User && ($user->roles || $user->group)) {
+			$roles = $user->roles;
+			if ($user->group && $user->group->roles) {
+				$roles = array_merge($roles, $user->group->roles);
+			}
 
-            foreach ($roles as $role) {
-                foreach ($role_id as $test_role) {
-                    $tocheck = $role->name;
+			foreach ($roles as $role) {
+				foreach ($role_id as $test_role) {
+					$tocheck = $role->name;
 
-                    // asterisk means "any of"
-                    if (substr($test_role, -2) === '.*') {
-                        // remove down to full stop on test_role
-                        $test_role = substr($test_role, 0, -1);
+					// asterisk means "any of"
+					if (substr($test_role, -2) === '.*') {
+						// remove down to full stop on test_role
+						$test_role = substr($test_role, 0, -1);
 
-                        // don't worry about the full stop, just go for a match against test role
-                        // anything more would be overkill
-                        $tocheck = substr($tocheck, 0, strlen($test_role));
-                    }
+						// don't worry about the full stop, just go for a match against test role
+						// anything more would be overkill
+						$tocheck = substr($tocheck, 0, strlen($test_role));
+					}
 
-                    if ($tocheck == $test_role) {
-                        return true;
-                    }
-                }
-            }
-        }
+					if ($tocheck == $test_role) {
+						return true;
+					}
+				}
+			}
+		}
 
-        return false;
-    }
-
-    /**
-     * Check if an INDEX exists on a table.
-     * This is a hack becaues DBUtil doesn't have this method and we
-     * shouldn't need to rely on a particular version of fuel-core
-     * @param  string $table_name      The table name to check on
-     * @param  string $index_name The index name to check for
-     * @return boolean			  Returns true if exists, false if doesn't
-     */
-    public static function check_index_exists($table_name, $index_name)
-    {
-        $dsn = \Config::get('db.'.\Config::get('db.active').'.connection.dsn');
-        foreach (explode(';', $dsn) as $dsn_part) {
-            $exploded = explode('=', $dsn_part);
-            if ($exploded[0] == 'dbname') {
-                $database_name = $exploded[1];
-                break;
-            }
-        }
-
-        if (!isset($database_name)) {
-            throw new Exception('Database Name not able to fetched from DSN string');
-        }
-
-        try {
-            $query = \DB::select('*')
-                ->from('information_schema.statistics')
-                ->where('table_schema', $database_name)
-                ->where('table_name', $table_name)
-                ->where('index_name', $index_name)
-                ->execute();
-
-            if ($query->count() > 0) {
-                return true;
-            }
-        } catch (\Exception $e) {
-            return false;
-        }
-        return false;
-    }
+		return false;
+	}
 }
 
 /* end of file auth.php */

--- a/classes/auth.php
+++ b/classes/auth.php
@@ -460,6 +460,46 @@ class Auth
 
         return false;
     }
+
+    /**
+     * Check if an INDEX exists on a table.
+     * This is a hack becaues DBUtil doesn't have this method and we
+     * shouldn't need to rely on a particular version of fuel-core
+     * @param  string $table_name      The table name to check on
+     * @param  string $index_name The index name to check for
+     * @return boolean			  Returns true if exists, false if doesn't
+     */
+    public static function check_index_exists($table_name, $index_name)
+    {
+        $dsn = \Config::get('db.'.\Config::get('db.active').'.connection.dsn');
+        foreach (explode(';', $dsn) as $dsn_part) {
+            $exploded = explode('=', $dsn_part);
+            if ($exploded[0] == 'dbname') {
+                $database_name = $exploded[1];
+                break;
+            }
+        }
+
+        if (!isset($database_name)) {
+            throw new Exception('Database Name not able to fetched from DSN string');
+        }
+
+        try {
+            $query = \DB::select('*')
+                ->from('information_schema.statistics')
+                ->where('table_schema', $database_name)
+                ->where('table_name', $table_name)
+                ->where('index_name', $index_name)
+                ->execute();
+
+            if ($query->count() > 0) {
+                return true;
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+        return false;
+    }
 }
 
 /* end of file auth.php */

--- a/classes/migration.php
+++ b/classes/migration.php
@@ -14,33 +14,13 @@ class Migration
      */
     public static function check_index_exists($table_name, $index_name)
     {
-        $dsn = \Config::get('db.'.\Config::get('db.active').'.connection.dsn');
-        foreach (explode(';', $dsn) as $dsn_part) {
-            $exploded = explode('=', $dsn_part);
-            if ($exploded[0] == 'dbname') {
-                $database_name = $exploded[1];
-                break;
-            }
-        }
+        $query = \DB::select('*')
+            ->from('information_schema.statistics')
+            ->where('table_schema', \DB::expr('DATABASE()'))
+            ->where('table_name', $table_name)
+            ->where('index_name', $index_name)
+            ->execute();
 
-        if (!isset($database_name)) {
-            throw new Exception('Database Name not able to fetched from DSN string');
-        }
-
-        try {
-            $query = \DB::select('*')
-                ->from('information_schema.statistics')
-                ->where('table_schema', $database_name)
-                ->where('table_name', $table_name)
-                ->where('index_name', $index_name)
-                ->execute();
-
-            if ($query->count() > 0) {
-                return true;
-            }
-        } catch (\Exception $e) {
-            return false;
-        }
-        return false;
+        return $query->count() > 0;
     }
 }

--- a/classes/migration.php
+++ b/classes/migration.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Auth;
+
+class Migration
+{
+    /**
+     * Check if an INDEX exists on a table.
+     * This is a hack becaues DBUtil doesn't have this method and we
+     * shouldn't need to rely on a particular version of fuel-core
+     * @param  string $table_name      The table name to check on
+     * @param  string $index_name The index name to check for
+     * @return boolean			  Returns true if exists, false if doesn't
+     */
+    public static function check_index_exists($table_name, $index_name)
+    {
+        $dsn = \Config::get('db.'.\Config::get('db.active').'.connection.dsn');
+        foreach (explode(';', $dsn) as $dsn_part) {
+            $exploded = explode('=', $dsn_part);
+            if ($exploded[0] == 'dbname') {
+                $database_name = $exploded[1];
+                break;
+            }
+        }
+
+        if (!isset($database_name)) {
+            throw new Exception('Database Name not able to fetched from DSN string');
+        }
+
+        try {
+            $query = \DB::select('*')
+                ->from('information_schema.statistics')
+                ->where('table_schema', $database_name)
+                ->where('table_name', $table_name)
+                ->where('index_name', $index_name)
+                ->execute();
+
+            if ($query->count() > 0) {
+                return true;
+            }
+        } catch (\Exception $e) {
+            return false;
+        }
+        return false;
+    }
+}

--- a/migrations/004_auth_create_permissiontables.php
+++ b/migrations/004_auth_create_permissiontables.php
@@ -42,7 +42,7 @@ class Auth_Create_Permissiontables
 			), array('id'));
 
 			// add a unique index on group and permission
-			if (! \Auth::check_index_exists($table.'_permissions', 'permission')) {
+			if (! \Auth\Migration::check_index_exists($table.'_permissions', 'permission')) {
 				\DBUtil::create_index($table.'_permissions', array('area', 'permission'), 'permission', 'UNIQUE');
 			}
 		}

--- a/migrations/004_auth_create_permissiontables.php
+++ b/migrations/004_auth_create_permissiontables.php
@@ -42,7 +42,9 @@ class Auth_Create_Permissiontables
 			), array('id'));
 
 			// add a unique index on group and permission
-			\DBUtil::create_index($table.'_permissions', array('area', 'permission'), 'permission', 'UNIQUE');
+			if (! \Auth::check_index_exists($table.'_permissions', 'permission')) {
+				\DBUtil::create_index($table.'_permissions', array('area', 'permission'), 'permission', 'UNIQUE');
+			}
 		}
 
 		// reset any DBUtil connection set

--- a/migrations/008_auth_create_providers.php
+++ b/migrations/008_auth_create_providers.php
@@ -57,7 +57,7 @@ class Auth_Create_Providers
 				'updated_at' => array('type' => 'int', 'constraint' => 11, 'default' => 0),
 			), array('id'));
 
-			if (! \Auth::check_index_exists($table, 'parent_id')) {
+			if (! \Auth\Migration::check_index_exists($table, 'parent_id')) {
 				\DBUtil::create_index($table, 'parent_id', 'parent_id');
 			}
 		}

--- a/migrations/008_auth_create_providers.php
+++ b/migrations/008_auth_create_providers.php
@@ -57,7 +57,9 @@ class Auth_Create_Providers
 				'updated_at' => array('type' => 'int', 'constraint' => 11, 'default' => 0),
 			), array('id'));
 
-			\DBUtil::create_index($table, 'parent_id', 'parent_id');
+			if (! \Auth::check_index_exists($table, 'parent_id')) {
+				\DBUtil::create_index($table, 'parent_id', 'parent_id');
+			}
 		}
 
 		// reset any DBUtil connection set

--- a/migrations/009_auth_create_oauth2tables.php
+++ b/migrations/009_auth_create_oauth2tables.php
@@ -58,7 +58,10 @@ class Auth_Create_Oauth2tables
 			'suspended' => array( 'type' => 'tinyint', 'constraint' => 1, 'default' => 0),
 			'notes' => array('type' => 'tinytext'),
 		), array('id'));
-		\DBUtil::create_index($basetable.'_clients', 'client_id', 'client_id', 'UNIQUE');
+
+		if (! \Auth::check_index_exists($basetable.'_clients', 'client_id')) {
+			\DBUtil::create_index($basetable.'_clients', 'client_id', 'client_id', 'UNIQUE');
+		}
 
 		\DBUtil::create_table($basetable.'_sessions',
 			array(
@@ -97,7 +100,10 @@ class Auth_Create_Oauth2tables
 			'name' => array('type' => 'varchar', 'constraint' => 64, 'default' => ''),
 			'description' => array('type' => 'varchar', 'constraint' => 255, 'default' => ''),
 		), array('id'));
-		\DBUtil::create_index($basetable.'_scopes', 'scope', 'scope', 'UNIQUE');
+
+		if (! \Auth::check_index_exists($basetable.'_scopes', 'scope')) {
+			\DBUtil::create_index($basetable.'_scopes', 'scope', 'scope', 'UNIQUE');
+		}
 
 		\DBUtil::create_table($basetable.'_sessionscopes',
 			array(
@@ -130,9 +136,16 @@ class Auth_Create_Oauth2tables
 				),
 			)
 		);
-		\DBUtil::create_index($basetable.'_sessionscopes', 'session_id', 'session_id');
-		\DBUtil::create_index($basetable.'_sessionscopes', 'access_token', 'access_token');
-		\DBUtil::create_index($basetable.'_sessionscopes', 'scope', 'scope');
+
+		if (! \Auth::check_index_exists($basetable.'_sessionscopes', 'session_id')) {
+			\DBUtil::create_index($basetable.'_sessionscopes', 'session_id', 'session_id');
+		}
+		if (! \Auth::check_index_exists($basetable.'_sessionscopes', 'access_token')) {
+			\DBUtil::create_index($basetable.'_sessionscopes', 'access_token', 'access_token');
+		}
+		if (! \Auth::check_index_exists($basetable.'_sessionscopes', 'scope')) {
+			\DBUtil::create_index($basetable.'_sessionscopes', 'scope', 'scope');
+		}
 
 		// reset any DBUtil connection set
 		$this->dbconnection(false);

--- a/migrations/009_auth_create_oauth2tables.php
+++ b/migrations/009_auth_create_oauth2tables.php
@@ -59,7 +59,7 @@ class Auth_Create_Oauth2tables
 			'notes' => array('type' => 'tinytext'),
 		), array('id'));
 
-		if (! \Auth::check_index_exists($basetable.'_clients', 'client_id')) {
+		if (! \Auth\Migration::check_index_exists($basetable.'_clients', 'client_id')) {
 			\DBUtil::create_index($basetable.'_clients', 'client_id', 'client_id', 'UNIQUE');
 		}
 
@@ -101,7 +101,7 @@ class Auth_Create_Oauth2tables
 			'description' => array('type' => 'varchar', 'constraint' => 255, 'default' => ''),
 		), array('id'));
 
-		if (! \Auth::check_index_exists($basetable.'_scopes', 'scope')) {
+		if (! \Auth\Migration::check_index_exists($basetable.'_scopes', 'scope')) {
 			\DBUtil::create_index($basetable.'_scopes', 'scope', 'scope', 'UNIQUE');
 		}
 
@@ -137,13 +137,13 @@ class Auth_Create_Oauth2tables
 			)
 		);
 
-		if (! \Auth::check_index_exists($basetable.'_sessionscopes', 'session_id')) {
+		if (! \Auth\Migration::check_index_exists($basetable.'_sessionscopes', 'session_id')) {
 			\DBUtil::create_index($basetable.'_sessionscopes', 'session_id', 'session_id');
 		}
-		if (! \Auth::check_index_exists($basetable.'_sessionscopes', 'access_token')) {
+		if (! \Auth\Migration::check_index_exists($basetable.'_sessionscopes', 'access_token')) {
 			\DBUtil::create_index($basetable.'_sessionscopes', 'access_token', 'access_token');
 		}
-		if (! \Auth::check_index_exists($basetable.'_sessionscopes', 'scope')) {
+		if (! \Auth\Migration::check_index_exists($basetable.'_sessionscopes', 'scope')) {
 			\DBUtil::create_index($basetable.'_sessionscopes', 'scope', 'scope');
 		}
 


### PR DESCRIPTION
This PR adds a new function `check_index_exists()` to the base Auth class, and uses this in migrations going to OrmAuth.

Resolves issue of duplicate indexes attempting to be created when migrating from SimpleAuth.